### PR TITLE
DLS-3692 stop breaking scalastyle by removing trailing commas

### DIFF
--- a/app/uk/gov/hmrc/helptosavetestadminfrontend/connectors/AuthConnector.scala
+++ b/app/uk/gov/hmrc/helptosavetestadminfrontend/connectors/AuthConnector.scala
@@ -54,7 +54,7 @@ class AuthConnector @Inject()(http: HttpClient, appConfig: AppConfig) extends Lo
               val session = Session(Map(
                 SessionKeys.sessionId -> SessionId(s"session-${UUID.randomUUID}").value,
                 SessionKeys.authToken -> token,
-                SessionKeys.lastRequestTimestamp -> DateTime.now.getMillis.toString,
+                SessionKeys.lastRequestTimestamp -> DateTime.now.getMillis.toString
               ))
 
               Right(SessionToken(session))

--- a/app/uk/gov/hmrc/helptosavetestadminfrontend/controllers/VerifiedEmailsController.scala
+++ b/app/uk/gov/hmrc/helptosavetestadminfrontend/controllers/VerifiedEmailsController.scala
@@ -31,7 +31,7 @@ class VerifiedEmailsController @Inject() (
                                            mcc: MessagesControllerComponents,
                                            errorHandler: ErrorHandler,
                                            specify_emails_to_delete: specify_emails_to_delete,
-                                           emails_deleted : emails_deleted,
+                                           emails_deleted : emails_deleted
                                          )(
                                           implicit val appConfig: AppConfig, ec: ExecutionContext
                                          ) extends AdminFrontendController(appConfig, mcc, errorHandler) with I18nSupport {


### PR DESCRIPTION
DLS-3692 stop breaking scalastyle by removing trailing commas (SIP-27).  The compiler appears to be accepting trailing commas but scalastyle not